### PR TITLE
[#165345969] Implement configuration properties in broker tester

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -318,3 +318,7 @@ func (b *Broker) LastBindingOperation(
 ) (brokerapi.LastOperation, error) {
 	return brokerapi.LastOperation{}, errors.New("not implemented")
 }
+
+func (b *Broker) GetInstance(ctx context.Context, instanceID string) (brokerapi.GetInstanceDetailsSpec, error) {
+	return brokerapi.GetInstanceDetailsSpec{}, errors.New("not implemented")
+}

--- a/testing/broker/broker_tester.go
+++ b/testing/broker/broker_tester.go
@@ -25,13 +25,16 @@ func New(credentials brokerapi.BrokerCredentials, brokerAPI http.Handler) Broker
 	}
 }
 
+type ConfigurationValues = map[string]interface{}
+
 type RequestBody struct {
-	ServiceID        string       `json:"service_id,omitempty"`
-	PlanID           string       `json:"plan_id,omitempty"`
-	OrganizationGUID string       `json:"organization_guid,omitempty"`
-	SpaceGUID        string       `json:"space_guid,omitempty"`
-	AppGUID          string       `json:"app_guid,omitempty"`
-	PreviousValues   *RequestBody `json:"previous_values,omitempty"`
+	ServiceID        string               `json:"service_id,omitempty"`
+	PlanID           string               `json:"plan_id,omitempty"`
+	OrganizationGUID string               `json:"organization_guid,omitempty"`
+	SpaceGUID        string               `json:"space_guid,omitempty"`
+	AppGUID          string               `json:"app_guid,omitempty"`
+	PreviousValues   *RequestBody         `json:"previous_values,omitempty"`
+	Parameters       *ConfigurationValues `json:"parameters,omitempty"`
 }
 
 func (bt BrokerTester) Services() *httptest.ResponseRecorder {


### PR DESCRIPTION
What
---
Allow passing arbitrary configuration parameters in broker tester

The Open Service Broker specification has the `parameters` field in most request bodies, for passing arbitrary configuration values. The service broker tester did not support this.

How to review
---
1. Code review

Who can review
---
Anyone